### PR TITLE
replace faulty line

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -60,7 +60,7 @@ contact: 'eamonn.bell@durham.ac.uk'
 # Order of episodes in your lesson
 episodes: 
 - introduction.md
-– overview.md
+- overview.md
 
 # Information for Learners
 learners: 


### PR DESCRIPTION
Something straneg seemed to have happened with this line of the config file -- perhaps a strange line ending introduced when copy/pasting on a Mac? Not really, sure TBH but anyway merging this should resolve the issue.